### PR TITLE
Add dataframe query support using ntc templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,25 @@ SwitchLore consolidates common functions I've developed across multiple tools in
 - **Data Organization** – Build a structured knowledge base (per-switch) from parsed configurations.
 - **Action Modules** – Run queries and operations against the data (e.g., inventorying interfaces, mapping neighbors, validating settings).
 
+## Querying Parsed Data
+
+`SwitchLore` provides a high-level interface that ties configuration files to
+their parsed command sections. After instantiating the class you can request one
+or more commands and receive the results as a Pandas `DataFrame`.
+
+```python
+from switchlore import SwitchLore
+
+ingestor = SwitchLore("/path/to/configs")
+df = ingestor.query([
+    "show mac address-table",
+    "show cdp neighbors detail",
+])
+```
+
+The resulting dataframe keeps track of the originating file for each parsed row
+and leverages [`ntc-templates`](https://github.com/networktocode/ntc-templates)
+under the hood.
+
 ## Goal
 Provide a centralized, reusable toolkit for working with network switch configurations, enabling efficient analysis, documentation, and topology mapping.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ntc_templates
+pandas

--- a/switchlore/__init__.py
+++ b/switchlore/__init__.py
@@ -1,5 +1,5 @@
 """SwitchLore package initialization."""
 
-from .ingestor import SwitchLoreBase
+from .ingestor import SwitchLore, SwitchLoreBase
 
-__all__ = ["SwitchLoreBase"]
+__all__ = ["SwitchLoreBase", "SwitchLore"]


### PR DESCRIPTION
## Summary
- add pandas and ntc_templates as project dependencies
- extend the ingestor with section iterators and a SwitchLore helper that parses sections with ntc-templates into dataframes
- document the new query workflow in the README

## Testing
- python -m compileall switchlore


------
https://chatgpt.com/codex/tasks/task_e_68ced8aa6a1083258eb2622a61e53138