### PR TITLE
Improve custom query actions and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,24 @@ The resulting dataframe keeps track of the originating file for each parsed row
 and leverages [`ntc-templates`](https://github.com/networktocode/ntc-templates)
 under the hood.
 
+### Handling Sections Without Templates
+
+Some configuration sections (such as interface blocks) do not have accompanying
+NTC templates. `SwitchLore.query` accepts structured specifications so you can
+request custom actions for those sections while keeping the API consistent.
+
+```python
+df = ingestor.query({
+    "section": "show running-config interface",
+    "action": "capture_interface_config",
+    "options": {"terminators": ["exit", "!"]},
+})
+```
+
+The resulting dataframe contains one row per interface with columns for the
+interface name, the captured configuration block, and the source file. You can
+mix these specifications with regular string commands (which default to
+`ntc_templates` parsing) to build richer automation workflows.
+
 ## Goal
 Provide a centralized, reusable toolkit for working with network switch configurations, enabling efficient analysis, documentation, and topology mapping.

--- a/tests/test_ingestor.py
+++ b/tests/test_ingestor.py
@@ -1,0 +1,195 @@
+"""Tests for the :mod:`switchlore.ingestor` module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Iterable
+from unittest import TestCase
+from unittest.mock import patch
+
+import pandas as pd
+
+from switchlore import SwitchLore
+
+
+class TestSwitchLoreQuery(TestCase):
+    """Unit tests covering the :meth:`SwitchLore.query` method."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._tmpdir = TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.base_path = Path(self._tmpdir.name)
+
+    def _write_config(self, lines: Iterable[str]) -> Path:
+        path = self.base_path / "switch.cfg"
+        content = "\n".join(lines)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def test_query_with_parse_action_uses_ntc_templates(self) -> None:
+        """String commands are still parsed using ``ntc_templates``."""
+
+        config_path = self._write_config(
+            [
+                "--- show cdp neighbors detail",
+                "Device ID: SwitchA",
+            ]
+        )
+
+        ingestor = SwitchLore(config_path)
+
+        with patch(
+            "switchlore.ingestor.parse_output",
+            return_value=[{"neighbor": "SwitchA"}],
+        ) as mock_parse:
+            df = ingestor.query(["show cdp neighbors detail"])
+
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(len(df), 1)
+        row = df.iloc[0]
+        self.assertEqual(row["neighbor"], "SwitchA")
+        self.assertEqual(row["command"], "show cdp neighbors detail")
+        self.assertEqual(row["source"], str(config_path.resolve()))
+
+        mock_parse.assert_called_once_with(
+            platform="cisco_ios",
+            command="show cdp neighbors detail",
+            data="Device ID: SwitchA",
+        )
+
+    def test_capture_interface_config_action_returns_interface_blocks(self) -> None:
+        """Custom action extracts interface configuration blocks."""
+
+        config_path = self._write_config(
+            [
+                "--- show running-config interface",
+                "interface GigabitEthernet1/0/1",
+                " description Uplink",
+                " switchport access vlan 10",
+                "!",
+                "interface Vlan10",
+                " ip address 10.10.10.1 255.255.255.0",
+                " no shutdown",
+                "exit",
+                "interface GigabitEthernet1/0/2",
+                " shutdown",
+            ]
+        )
+
+        ingestor = SwitchLore(config_path)
+
+        df = ingestor.query(
+            [
+                {
+                    "section": "show running-config interface",
+                    "action": "capture_interface_config",
+                }
+            ]
+        )
+
+        self.assertEqual(df["interface"].tolist(), [
+            "GigabitEthernet1/0/1",
+            "Vlan10",
+            "GigabitEthernet1/0/2",
+        ])
+
+        config_values = df["configuration"].tolist()
+        self.assertTrue(config_values[0].startswith("interface GigabitEthernet1/0/1"))
+        self.assertIn("description Uplink", config_values[0])
+        self.assertIn("ip address 10.10.10.1 255.255.255.0", config_values[1])
+        self.assertIn("shutdown", config_values[2])
+        self.assertNotIn("raw", df.columns)
+
+    def test_capture_interface_config_with_alias_and_raw_column(self) -> None:
+        """Aliases and ``include_raw`` interact correctly for interface capture."""
+
+        config_path = self._write_config(
+            [
+                "--- show running-config interface",
+                "interface Loopback0",
+                " ip address 192.0.2.1 255.255.255.255",
+                " quit",
+                "Some unrelated line",
+                "PORT: Ethernet1",
+                " description Test port",
+                "ENDPORT",
+            ]
+        )
+
+        ingestor = SwitchLore(config_path)
+
+        df = ingestor.query(
+            [
+                {
+                    "section": "show running-config interface",
+                    "action": "capture_interfaces",
+                    "options": {
+                        "terminators": ["quit", "ENDPORT"],
+                        "interface_pattern": r"^(?:interface|PORT:)\s+(.+)$",
+                    },
+                }
+            ],
+            include_raw=True,
+        )
+
+        self.assertEqual(df["interface"].tolist(), ["Loopback0", "Ethernet1"])
+        self.assertIn("raw", df.columns)
+        self.assertIn("interface Loopback0", df["configuration"].iloc[0])
+        self.assertIn("PORT: Ethernet1", df["configuration"].iloc[1])
+        self.assertEqual(df["raw"].iloc[0], df["configuration"].iloc[0])
+        self.assertEqual(df["raw"].iloc[1], df["configuration"].iloc[1])
+        self.assertNotEqual(df["raw"].iloc[0], df["raw"].iloc[1])
+
+    def test_query_accepts_single_mapping_specification(self) -> None:
+        """A lone command mapping can be supplied without wrapping it in a list."""
+
+        config_path = self._write_config(
+            [
+                "--- show running-config interface",
+                "interface GigabitEthernet1/0/10",
+                " description Access port",
+                " switchport access vlan 20",
+                " exit",
+            ]
+        )
+
+        ingestor = SwitchLore(config_path)
+
+        df = ingestor.query(
+            {
+                "section": "show running-config interface",
+                "action": "capture_interface_config",
+            },
+            include_raw=True,
+        )
+
+        self.assertEqual(df["interface"].tolist(), ["GigabitEthernet1/0/10"])
+        self.assertEqual(df["raw"].iloc[0], df["configuration"].iloc[0])
+        self.assertIn("switchport access vlan 20", df["raw"].iloc[0])
+
+    def test_invalid_command_mapping_raises(self) -> None:
+        """Invalid command specifications raise descriptive exceptions."""
+
+        config_path = self._write_config(
+            ["--- show inventory", "Chassis"]
+        )
+
+        ingestor = SwitchLore(config_path)
+
+        with self.assertRaises(TypeError):
+            ingestor.query([{ "section": 42 }])
+
+        with self.assertRaises(ValueError):
+            ingestor.query([{"action": "capture_interface_config"}])
+
+        with self.assertRaises(ValueError):
+            ingestor.query(
+                [
+                    {
+                        "section": "show running-config interface",
+                        "action": "unknown",
+                    }
+                ]
+            )


### PR DESCRIPTION
## Summary
- allow `SwitchLore.query` to accept a single command mapping alongside sequences and keep the API backward compatible
- refine interface configuration capture to preserve header formatting, honour compiled regex patterns, and emit per-interface raw blocks
- document custom section handling in the README and extend unit tests to cover the updated behaviours

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68cee74dce80832580909262dd9c5fb5